### PR TITLE
Add docker compose support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace with your Discord token
+DISCORD_TOKEN=YOUR_TOKEN_HERE

--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ The bot will print a message when it successfully connects to Discord.
    ```bash
    docker run -e DISCORD_TOKEN=YOUR_TOKEN kudl-chatbot
    ```
+
+## Docker Compose
+
+1. Copy `.env.example` to `.env` and update the token:
+   ```bash
+   cp .env.example .env
+   # edit .env and set DISCORD_TOKEN
+   ```
+2. Build and start the container:
+   ```bash
+   docker compose up --build
+   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  bot:
+    build: .
+    env_file:
+      - .env
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- support docker compose to run the Discord bot
- provide env file example for compose
- document compose usage

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684b3bd256d4832496c022cab2456341