### PR TITLE
Integrate Qdrant and Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kudl-chatbot
 
-This is a minimal Discord bot built with [discord.py](https://discordpy.readthedocs.io/).
+This bot connects to a Qdrant vector database and uses [Ollama](https://ollama.ai/) models to reply in Discord.
 
 ## Setup
 
@@ -9,10 +9,14 @@ This is a minimal Discord bot built with [discord.py](https://discordpy.readthed
    python -m pip install -r requirements.txt
    ```
 2. Create a Discord bot and copy its token.
-3. Set the token in the `DISCORD_TOKEN` environment variable:
-   ```bash
-   export DISCORD_TOKEN=YOUR_TOKEN_HERE
-   ```
+3. Set the token in the `DISCORD_TOKEN` environment variable and provide connection details for Qdrant and Ollama:
+  ```bash
+  export DISCORD_TOKEN=YOUR_TOKEN_HERE
+  export QDRANT_HOST=your-qdrant-host
+  export QDRANT_PORT=6333
+  export QDRANT_API_KEY=your-qdrant-key
+  export OLLAMA_MODEL=llama2
+  ```
 4. Run the bot:
    ```bash
    python bot.py
@@ -26,7 +30,12 @@ The bot will print a message when it successfully connects to Discord.
    ```bash
    docker build -t kudl-chatbot .
    ```
-2. Run the container with your Discord token:
+2. Run the container with the required environment variables:
    ```bash
-   docker run -e DISCORD_TOKEN=YOUR_TOKEN kudl-chatbot
+   docker run -e DISCORD_TOKEN=YOUR_TOKEN \
+              -e QDRANT_HOST=your-qdrant-host \
+              -e QDRANT_PORT=6333 \
+              -e QDRANT_API_KEY=your-qdrant-key \
+              -e OLLAMA_MODEL=llama2 \
+              kudl-chatbot
    ```

--- a/bot.py
+++ b/bot.py
@@ -1,16 +1,70 @@
 import os
+from typing import List
+
 import discord
 from discord.ext import commands
+from qdrant_client import QdrantClient
+import ollama
 
 TOKEN = os.environ.get('DISCORD_TOKEN')
+QDRANT_HOST = os.environ.get('QDRANT_HOST', 'localhost')
+QDRANT_PORT = int(os.environ.get('QDRANT_PORT', '6333'))
+QDRANT_API_KEY = os.environ.get('QDRANT_API_KEY')
+
+OLLAMA_MODEL = os.environ.get('OLLAMA_MODEL', 'llama2')
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT, api_key=QDRANT_API_KEY)
+COLLECTION_NAME = os.environ.get('QDRANT_COLLECTION', 'kudl_messages')
 
 intents = discord.Intents.default()
+intents.message_content = True
 
 bot = commands.Bot(command_prefix='!', intents=intents)
+
+
+def get_context(question: str, limit: int = 5) -> str:
+    """Retrieve similar messages from Qdrant and return them as context."""
+    embedding = ollama.embeddings(model=OLLAMA_MODEL, prompt=question)["embedding"]
+    search_result = client.search(
+        collection_name=COLLECTION_NAME,
+        query_vector=embedding,
+        limit=limit,
+    )
+    snippets: List[str] = []
+    for point in search_result:
+        payload = point.payload or {}
+        text = payload.get("text")
+        if text:
+            snippets.append(text)
+    return "\n".join(snippets)
+
+
+def generate_response(question: str, context: str) -> str:
+    """Generate a reply using Ollama."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+    ]
+    if context:
+        messages.append({"role": "system", "content": f"Context:\n{context}"})
+    messages.append({"role": "user", "content": question})
+    response = ollama.chat(model=OLLAMA_MODEL, messages=messages)
+    return response['message']['content'].strip()
 
 @bot.event
 async def on_ready():
     print(f'{bot.user} has connected to Discord!')
+
+
+@bot.event
+async def on_message(message: discord.Message):
+    if message.author == bot.user:
+        return
+
+    question = message.content
+    context = get_context(question)
+    answer = generate_response(question, context)
+    await message.channel.send(answer)
+    await bot.process_commands(message)
 
 if __name__ == '__main__':
     if not TOKEN:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 discord.py>=2.3.2
+qdrant-client>=1.7.0
+ollama>=0.1.4


### PR DESCRIPTION
## Summary
- add Qdrant and Ollama to the bot
- respond to messages using retrieved context
- document new environment variables for setup and Docker usage
- include new dependencies

## Testing
- `pip install --no-cache-dir -r requirements.txt`
- `python -m py_compile bot.py`
- `python bot.py` *(fails: DISCORD_TOKEN environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_684b3c873a8083249e1c6aee71e7eca8